### PR TITLE
fix: Add default param set name for Get-EntraIDTrustingApplicationAccessToken

### DIFF
--- a/EntraIDAccessToken/Private/Get-EntraIDTrustingApplicationAccessToken.ps1
+++ b/EntraIDAccessToken/Private/Get-EntraIDTrustingApplicationAccessToken.ps1
@@ -1,5 +1,5 @@
 function Get-EntraIDTrustingApplicationAccessToken {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = "default")]
 
     Param(
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
Signed-off-by: Marius Solbakken Mellum <marius.solbakken@fortytwo.io>