### PR TITLE
fix: Error for certain configurations (presumably) because $Certificate was handled as a global variable

### DIFF
--- a/EntraIDAccessToken/Private/Get-EntraIDClientCertificateAccessToken.ps1
+++ b/EntraIDAccessToken/Private/Get-EntraIDClientCertificateAccessToken.ps1
@@ -17,7 +17,7 @@ function Get-EntraIDClientCertificateAccessToken {
             "aud" = "https://login.microsoftonline.com/$($AccessTokenProfile.TenantId)/oauth2/token"
             "iss" = $AccessTokenProfile.ClientId
             "sub" = $AccessTokenProfile.ClientId
-        } -Certificate $Certificate
+        } -Certificate $AccessTokenProfile.Certificate
 
         if ($AccessTokenProfile.V2Token) {
             $body = @{

--- a/EntraIDAccessToken/Public/Add-EntraIDClientCertificateAccessTokenProfile.ps1
+++ b/EntraIDAccessToken/Public/Add-EntraIDClientCertificateAccessTokenProfile.ps1
@@ -50,32 +50,38 @@ function Add-EntraIDClientCertificateAccessTokenProfile {
             Write-Warning "Profile $Name already exists, overwriting"
         }
 
-        if($PSCmdlet.ParameterSetName -eq "x509certificate2") {
+        $Certificate = $null;
+
+        if ($PSCmdlet.ParameterSetName -eq "x509certificate2") {
             
-        } elseif($PSCmdlet.ParameterSetName -eq "thumbprint") {
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq "thumbprint") {
             $localmachine = Get-ChildItem Cert:\LocalMachine\My | Where-Object ThumbPrint -eq $Thumbprint | Select-Object -First 1
             $currentuser = Get-ChildItem Cert:\CurrentUser\My | Where-Object ThumbPrint -eq $Thumbprint | Select-Object -First 1
 
-            if($localmachine) {
+            if ($localmachine) {
                 $Certificate = $localmachine
-            } elseif($currentuser) {
+            }
+            elseif ($currentuser) {
                 $Certificate = $currentuser
-            } else {
+            }
+            else {
                 throw "Certificate with thumbprint $Thumbprint not found"
             }
-        } elseif($PSCmdlet.ParameterSetName -eq "pfx") {
-            if(!(Test-Path $Path)) {
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq "pfx") {
+            if (!(Test-Path $Path)) {
                 throw "Path $Path does not exist"
             }
 
             $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($Path, $Password)
         }
 
-        if(!$Certificate) {
+        if (!$Certificate) {
             throw "Certificate not found"
         }
 
-        if(!$Certificate.HasPrivateKey) {
+        if (!$Certificate.HasPrivateKey) {
             throw "Certificate $($Certificate.Thumbprint) does not have a private key"
         }
         
@@ -91,6 +97,7 @@ function Add-EntraIDClientCertificateAccessTokenProfile {
             Scope                = $Scope
             TenantId             = $TenantId
             Certificate          = $Certificate
+            ThumbPrint           = $Certificate.Thumbprint
             V2Token              = $TokenVersion -eq "v2"
         }
 

--- a/EntraIDAccessToken/Public/Get-EntraIDAccessTokenProfile.ps1
+++ b/EntraIDAccessToken/Public/Get-EntraIDAccessTokenProfile.ps1
@@ -30,6 +30,7 @@ function Get-EntraIDAccessTokenProfile {
             @{L="ClientId";E={$_.Value.ClientId}},
             @{L="TrustingApplicationClientId";E={$_.Value.TrustingApplicationClientId}},
             @{L="Scope";E={$_.Value.Scope}},
-            @{L="V2Token";E={$_.Value.V2Token}}
+            @{L="V2Token";E={$_.Value.V2Token}},
+            @{L="Thumbprint";E={$_.Value.Thumbprint}}
     }
 }


### PR DESCRIPTION
Signed-off-by: Marius Solbakken Mellum <marius.solbakken@fortytwo.io>