### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish Module
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fortytwoservices/powershell-module-entraidaccesstoken/security/code-scanning/1](https://github.com/fortytwoservices/powershell-module-entraidaccesstoken/security/code-scanning/1)

To fix this issue, we need to explicitly declare a `permissions` block in the workflow so that the job does not use excessive and potentially risky default permissions. The minimal required permission is usually `contents: read`, unless the workflow needs additional access. Reviewing the steps: the workflow is triggered by a tagged push, checks out code, installs dependencies, and publishes to PowerShell Gallery (using a secret API key), but does not perform any repository write operations (e.g., creating issues, writing to repository, updating pull requests). Therefore, adding `permissions: contents: read` at the workflow (top) level is sufficient. To implement, insert a `permissions` block with `contents: read` near the top of `.github/workflows/publish.yml`, preferably after the workflow name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
