### PR TITLE
Fix payload decoding by replacing characters

### DIFF
--- a/EntraIDAccessToken/Public/Get-EntraIDAccessTokenPayload.ps1
+++ b/EntraIDAccessToken/Public/Get-EntraIDAccessTokenPayload.ps1
@@ -24,7 +24,7 @@ function Get-EntraIDAccessTokenPayload {
         }
 
         $payload = $InputObject.Split(".")[1]
-        $payload = $payload.PadRight($payload.Length + (4 - ($payload.Length % 4)), "=").Replace("====", "")
+        $payload = $payload.PadRight($payload.Length + (4 - ($payload.Length % 4)), "=").Replace("====", "").Replace("-","+").Replace("_","/")
         ConvertFrom-Json -InputObject ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($payload))) -AsHashtable:$AsHashTable
     }
 }


### PR DESCRIPTION
The Script Assumes that the Payload is Base64 Encoded, when it is in Fact Base64 URL Encoded. This throws an unhandled Exception as soon as either the "_" or "+" Character are part of the payload.

See for Example The [Description of URL Base64](https://medium.com/@bagdasaryanaleksandr97/understanding-base64-vs-base64-url-encoding-whats-the-difference-31166755bc26) vs the allowed characters described in the [.Net Function Definition](https://learn.microsoft.com/en-us/dotnet/api/system.convert.frombase64string?view=net-10.0#remarks)